### PR TITLE
Task24/setup tests

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -143,3 +143,5 @@ dmypy.json
 .prof
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+
+tests/last_test.log

--- a/server/run_tests.bat
+++ b/server/run_tests.bat
@@ -1,0 +1,1 @@
+pytest -v

--- a/server/server.py
+++ b/server/server.py
@@ -12,18 +12,8 @@ logger = logging.getLogger(__name__)
 logger.debug("Logger is configured!")
 
 
-
-@app.route('/')
-def hello_world():
-    return 'Hello, World!'
-
-
-
-
-
 def create_app() -> Flask:
     app = Flask(__name__)
-
     api = Api(app)
     api.add_resource(Item, '/items', '/items/<string:item_id>', endpoint='items')
     return app 
@@ -34,7 +24,5 @@ if __name__ == '__main__':
     # Runs at localhost:5000 
     logger.info("Starting app...")
     app = create_app()
-    @app.route('/')
-    def hello_world():
-        return 'Hello, World!'
+
     app.run(debug=True)

--- a/server/server.py
+++ b/server/server.py
@@ -11,8 +11,6 @@ logging.config.dictConfig(DEFAULT_LOGGING)
 logger = logging.getLogger(__name__)
 logger.debug("Logger is configured!")
 
-app = Flask(__name__)
-api = Api(app)
 
 
 @app.route('/')
@@ -20,14 +18,23 @@ def hello_world():
     return 'Hello, World!'
 
 
-api.add_resource(Item, '/items', '/items/<string:item_id>', endpoint='items')
 
-logger.info("Hallo!")
 
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    api = Api(app)
+    api.add_resource(Item, '/items', '/items/<string:item_id>', endpoint='items')
+    return app 
 
 if __name__ == '__main__':
     # The following line commented out line makes the server accessible from other PCs in the same network at port 80
     # app.run(host='0.0.0.0', port=80, debug=True)
     # Runs at localhost:5000 
-    logger.error("Starting app")
+    logger.info("Starting app...")
+    app = create_app()
+    @app.route('/')
+    def hello_world():
+        return 'Hello, World!'
     app.run(debug=True)

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,41 @@
+import sys, os
+from pathlib import Path
+from typing import Generator
+from testing_utils import delete_all_testbenches
+parent_dir = Path((os.path.dirname(os.path.abspath(__file__)))).parent
+sys.path.insert(0, str(parent_dir)) 
+
+import pytest
+from flask.testing import FlaskClient
+
+import server   
+
+"""
+Fixtures are a pytest construct that can be used to encapsulate repeating functionality that can be shared across tests.
+
+You define a fixture, that usually returns/yields some sort of an object. 
+In your test function, you add an argument with the name of the fixture, then at runtime, the pytest framework injects that fixture into your test.
+
+e.g. you can use the client from below in any test you wish, by simply supplying an arg called client to the test function:
+def test_example(client):
+    # here you now have access to the FlaskClient from below. You can then use it to test the backend:
+    response = client.get('localhost')
+
+    assert response.status_code == 200
+    assert response.json == ...
+"""
+
+"""This fixture provides a flask test client. Currently, a new (clean) client is generated for each test function. 
+This can be changed using the 'scope' keyword arg to the fixture.
+"""
+@pytest.fixture(scope="function")   
+def client() -> Generator[FlaskClient, None, None]:
+    # Test setup code be added before the yield statement and it will be executed before running the test
+    server.create_app().config['TESTING'] = True
+    with server.create_app().test_client() as client:
+        yield client
+    
+    # Any code added here is "teardown" code, which will be executed, once a test finishes execution.
+        
+    
+

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,14 +1,18 @@
 import sys, os
 from pathlib import Path
-from typing import Generator
-from testing_utils import delete_all_testbenches
+
+# For some reason sys.path.insert(0, ../) to get the parent directory isnt working here, so had to go for the following:  
 parent_dir = Path((os.path.dirname(os.path.abspath(__file__)))).parent
 sys.path.insert(0, str(parent_dir)) 
+
+from typing import Generator
+
 
 import pytest
 from flask.testing import FlaskClient
 
-import server   
+import server
+
 
 """
 Any pytest construct defined within the conftest.py file can be accessed by all testcases within and below this directory structure. 
@@ -36,7 +40,7 @@ def client() -> Generator[FlaskClient, None, None]:
     server.create_app().config['TESTING'] = True
     with server.create_app().test_client() as client:
         yield client
-    
+
     # Any code added here is "teardown" code, which will be executed, once a test finishes execution.
         
     

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -11,6 +11,8 @@ from flask.testing import FlaskClient
 import server   
 
 """
+Any pytest construct defined within the conftest.py file can be accessed by all testcases within and below this directory structure. 
+
 Fixtures are a pytest construct that can be used to encapsulate repeating functionality that can be shared across tests.
 
 You define a fixture, that usually returns/yields some sort of an object. 

--- a/server/tests/run_and_log.bat
+++ b/server/tests/run_and_log.bat
@@ -1,0 +1,1 @@
+pytest > tests/last_test.log

--- a/server/tests/test_resources/test_item.py
+++ b/server/tests/test_resources/test_item.py
@@ -1,0 +1,18 @@
+import sys 
+sys.path.insert(0, '../')
+
+from flask.testing import FlaskClient
+from flask.wrappers import Response
+
+ITEMS_URL = "/items"
+
+def test_get_item(client: FlaskClient): 
+    # get item
+    response: Response = client.get(ITEMS_URL)
+
+    # make assertions 
+    assert response.status_code == 200
+    
+    # TODO: Obviously the following assertion should be changed once we have actual functionality here
+    assert response.json == "Item Retrieved"
+


### PR DESCRIPTION
Setup the flask client for unit testing and added an example test. The same concept can be used for further tests. 

All tests must be within the tests/ folder. Could be a subfolder too. Folder name must start with test_*. The name of the test file must also start with test, i.e. test_*.py -> the name of each test function must also start with test: e.g. 
`def test_example(client):
     assert ...`
Pytest automatically detects all functions whose name starts with test_ and are inside the tests/ folder. The client argument in this case refers to the 'client' fixture that I defined in conftest.py... Pytest look for these function arguments that have the same name as the fixture and injects the fixture at runtime. Refer to the comments in conftest.py or to the pytest docs. 